### PR TITLE
Fix link in H5Coro README

### DIFF
--- a/packages/h5/README.md
+++ b/packages/h5/README.md
@@ -1,6 +1,6 @@
 # H5 Overview
 
-See https://slideruleearth.io/h5coro/
+See https://slideruleearth.io/rtd/user_guide/H5Coro.html
 
 ## Install zlib
 


### PR DESCRIPTION
<https://slideruleearth.io/h5coro/> results in a 404 Page Not Found.